### PR TITLE
Source branch selection + Windows support

### DIFF
--- a/src/codebase-review.js
+++ b/src/codebase-review.js
@@ -8,6 +8,7 @@ const { getRepoUrl, checkForUncommittedChanges } = require('../lib/git-helpers')
 const branchPrefix = argv.prefix || 'codebase-review';
 const emptyBranchName = `${branchPrefix}-empty`;
 const projectBranchName = `${branchPrefix}-project`;
+const sourceBranchName = argv.source || 'master';
 
 const handleEmptyBranchCreation = () => {
   return runCommand(`git branch -a | grep ${emptyBranchName} | wc -l`)
@@ -39,9 +40,9 @@ const run = () => {
   .then(() => runCommand(`git checkout -b ${projectBranchName}`, `Creating new project branch(${projectBranchName})...`))
   .then(() => runCommand(`git add --all`, 'Adding any hidden files...'))
   .then(() => runCommand(`git commit -am "Handling hidden files"`, 'Commiting any hidden files...'))
-  .then(() => runCommand('git merge master --allow-unrelated-histories > /dev/null', 'Merging master into project branch...'))
+  .then(() => runCommand(`git merge ${sourceBranchName} --allow-unrelated-histories > /dev/null`, `Merging ${sourceBranchName} into project branch...`))
   .then(() => runCommand(`git push --set-upstream origin ${projectBranchName} --force`, `Pushing ${projectBranchName} branch...`))
-  .then(() => runCommand('git checkout master', 'Returning to master branch'))
+  .then(() => runCommand(`git checkout ${sourceBranchName}`, `Returning to ${sourceBranchName} branch`))
   .then(() => runCommand(`git branch -D ${emptyBranchName} ${projectBranchName}`, 'Clearing Codebase Review branches'))
   .then(getRepoUrl)
   .then((repoUrl) => {


### PR DESCRIPTION
(Apologies for two unrelated changes in one PR, but they were both so small it seemed overkill to split them.)

Default behaviour on OSX/Linux is unchanged, PR adds the following:

1. Check for the existence of `/dev/null` before we send output to it; if it doesn't exist, we can reasonably assume we're on Windows, where `NUL` is the equivalent, so we use that. Anywhere that this assumption is incorrect will currently be broken anyway, so at worst this is the same as before.
2. Add a `--source` option to review code from somewhere other than `master`. `codebase-review --source other_branch` will merge `other_branch` into `codebase-review-project` (or whatever prefixed branch is specified). Useful when working on a `develop` branch or similar. Default behaviour is unchanged (and equivalent to `codebase-review --source master`).